### PR TITLE
Correct `ar_sl_rtl` label and description

### DIFF
--- a/simplelightbox.php
+++ b/simplelightbox.php
@@ -324,9 +324,9 @@ class SimpleLightbox {
                 'desc'  => __('adds class to html element if lightbox is open. If empty or false no class is set', 'simplelightbox')
             ),
             'ar_sl_rtl' => array(
-                'type' => 'checkbox',
-                'label' => __('Close on browser back button','simplelightbox'),
-                'desc' => __('enable history back closes lightbox instead of reloading the page','simplelightbox')
+                'type'  => 'checkbox',
+                'label' => __('Enable RTL direction','simplelightbox'),
+                'desc'  => __('advance slides with the left arrow or left button, for use with content in right-to-left languages','simplelightbox')
             ),
             'ar_sl_fixedClass' => array(
                 'type'  => 'text',


### PR DESCRIPTION
The label and description for the RTL navigation option mistakenly re-uses the text for the history option.

This pull request creates some text to describe the RTL option, though I'm sure it can be improved.